### PR TITLE
modify getNextValue include nextState and output

### DIFF
--- a/Lec_2_State_Machine/parking_gate.py
+++ b/Lec_2_State_Machine/parking_gate.py
@@ -10,45 +10,38 @@ class FreeGate(SM):
         free gate initial state always 'waiting'
         """
         super().__init__('waiting')
-
-    def generateOuput(self, nextState, inp):
-        # nextState = self.generateState(state, inp)
-        if nextState == 'raising' :
-            return 'lift'
-        elif nextState == 'lowering' :
-            return 'drop'
-        else :
-            return 'nop'
     
-    def generateState(self, state, inp):
-        gatePos, carIn, carOut = inp
-         # detect run over (the most bold one:  just straight runover gate)
-        if state == 'waiting' and carOut:
-            raise RunOverViolation('Run Over')
-        if state == 'waiting' and carIn:
-            return 'raising'
-        elif state == 'raising' and gatePos == 'top':
-            return 'raised'
-        # detect run over:
-        elif state == 'raising' and gatePos == 'bottom' and carOut: 
-            raise RunOverViolation("Run Over")
-        # detect too soon violation:
-        elif state == 'raising' and gatePos == 'middle' and carOut:
-            raise TooSoonViolation('Too Soon')
-        elif state == 'raised' and carOut:
-            return 'lowering'
-        # detecting too soon violation while drop
-        elif state == 'lowering' and gatePos == 'middle' and carOut:
-            raise TooSoonViolation('Too Soon')
-        elif state == 'lowering' and gatePos == 'bottom' :
-            return 'waiting'
-        else:
-            return state
     
     def getNextValues(self, state, inp, fn=..., fo=..., efn=None, efo=None) -> tuple:
-        nextState = self.generateState(state, inp)
+        gatePos, carIn, carOut = inp
+        # detect violations
+        if state == 'waiting' and carOut : raise RunOverViolation('halt')
+        if state == 'raising' and gatePos == 'bottom' and carOut : raise RunOverViolation('halt')
+        if state == 'raising' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
+        if state == 'lowering' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
+
+        # determine next state:
+        if state == 'waiting' and carIn:
+            nextState = 'raising'
+        elif state == 'raising' and gatePos == 'top':
+            nextState = 'raised'
+        elif state == 'raised' and carOut:
+            nextState = 'lowering'
+        elif state == 'lowering' and gatePos == 'bottom' :
+            nextState = 'waiting'
+        else:
+            nextState = state
+        
+        # determine the ouput:
+        if nextState == 'raising' :
+            output = 'lift'
+        elif nextState == 'lowering' :
+            output = 'drop'
+        else :
+            output = 'nop'
+
         fn = lambda s,i : nextState
-        fo = lambda s,i : self.generateOuput(nextState, inp)
+        fo = lambda s,i : output
         return super().getNextValues(state, inp, fn, fo, efn, efo)
 
 class RunOverViolation(Exception):

--- a/Lec_2_State_Machine/parking_gate.py
+++ b/Lec_2_State_Machine/parking_gate.py
@@ -13,36 +13,38 @@ class FreeGate(SM):
     
     
     def getNextValues(self, state, inp, fn=..., fo=..., efn=None, efo=None) -> tuple:
-        gatePos, carIn, carOut = inp
-        # detect violations
-        if state == 'waiting' and carOut : raise RunOverViolation('halt')
-        if state == 'raising' and gatePos == 'bottom' and carOut : raise RunOverViolation('halt')
-        if state == 'raising' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
-        if state == 'lowering' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
+        try :
+            gatePos, carIn, carOut = inp
+            # detect violations
+            if state == 'waiting' and carOut : raise RunOverViolation('halt')
+            if state == 'raising' and gatePos == 'bottom' and carOut : raise RunOverViolation('halt')
+            if state == 'raising' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
+            if state == 'lowering' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
 
-        # determine next state:
-        if state == 'waiting' and carIn:
-            nextState = 'raising'
-        elif state == 'raising' and gatePos == 'top':
-            nextState = 'raised'
-        elif state == 'raised' and carOut:
-            nextState = 'lowering'
-        elif state == 'lowering' and gatePos == 'bottom' :
-            nextState = 'waiting'
-        else:
-            nextState = state
+            # determine next state:
+            if state == 'waiting' and carIn:
+                nextState = 'raising'
+            elif state == 'raising' and gatePos == 'top':
+                nextState = 'raised'
+            elif state == 'raised' and carOut:
+                nextState = 'lowering'
+            elif state == 'lowering' and gatePos == 'bottom' :
+                nextState = 'waiting'
+            else:
+                nextState = state
+            
+            # determine the ouput:
+            if nextState == 'raising' :
+                output = 'lift'
+            elif nextState == 'lowering' :
+                output = 'drop'
+            else :
+                output = 'nop'
+            
+            return (nextState, output)
+        except Exception as e:
+            return(self.fnErr(state, inp, e), self.foErr(state, inp, e))
         
-        # determine the ouput:
-        if nextState == 'raising' :
-            output = 'lift'
-        elif nextState == 'lowering' :
-            output = 'drop'
-        else :
-            output = 'nop'
-
-        fn = lambda s,i : nextState
-        fo = lambda s,i : output
-        return super().getNextValues(state, inp, fn, fo, efn, efo)
 
 class RunOverViolation(Exception):
     """  

--- a/Lec_2_State_Machine/parking_gate.py
+++ b/Lec_2_State_Machine/parking_gate.py
@@ -16,10 +16,10 @@ class FreeGate(SM):
         try :
             gatePos, carIn, carOut = inp
             # detect violations
-            if state == 'waiting' and carOut : raise RunOverViolation('halt')
-            if state == 'raising' and gatePos == 'bottom' and carOut : raise RunOverViolation('halt')
-            if state == 'raising' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
-            if state == 'lowering' and gatePos == 'middle' and carOut : raise TooSoonViolation('halt')
+            if state == 'waiting' and carOut : raise RunOverViolation('ALERT! run off')
+            if state == 'raising' and gatePos == 'bottom' and carOut : raise RunOverViolation('ALERT! run off')
+            if state == 'raising' and gatePos == 'middle' and carOut : raise TooSoonViolation('ALERT! too soon')
+            if state == 'lowering' and gatePos == 'middle' and carOut : raise TooSoonViolation('ALERT! too soon')
 
             # determine next state:
             if state == 'waiting' and carIn:
@@ -44,6 +44,10 @@ class FreeGate(SM):
             return (nextState, output)
         except Exception as e:
             return(self.fnErr(state, inp, e), self.foErr(state, inp, e))
+
+    def fnErr(self, state, inp, err):
+        state = 'halt'
+        return super().fnErr(state, inp, err)
         
 
 class RunOverViolation(Exception):

--- a/test/test_parking_gate.py
+++ b/test/test_parking_gate.py
@@ -66,10 +66,12 @@ class TestFreeGate(unittest.TestCase):
         inputs = [('bottom', False, False), ('bottom', True, False), ('bottom', False, True)]
 
         # assert 
-        with self.assertRaises(Exception) as e:
-            self.gate.transduce(inputs)
+        # with self.assertRaises(Exception) as e:
+        #     self.gate.transduce(inputs)
         
-        self.assertTrue(type(e.exception) is pg.RunOverViolation, "TYPE OF EXCEPTION IS WRONG")
+        # self.assertTrue(type(e.exception) is pg.RunOverViolation, "TYPE OF EXCEPTION IS WRONG")
+        self.assertTrue(self.gate.transduce(inputs), ['nop', 'lift', 'ALERT! run off'])
+        self.assertEqual(self.gate.getState(), 'halt', "Violation state is wrong")
 
         # RESET THE GATE
         self.gate.start()
@@ -77,10 +79,12 @@ class TestFreeGate(unittest.TestCase):
         inputs = [('bottom', False, False), ('bottom', False, True)]
 
         # assert 
-        with self.assertRaises(Exception) as e:
-            self.gate.transduce(inputs)
+        # with self.assertRaises(Exception) as e:
+        #     self.gate.transduce(inputs)
         
-        self.assertTrue(type(e.exception) is pg.RunOverViolation, "TYPE OF EXCEPTION IS WRONG")
+        # self.assertTrue(type(e.exception) is pg.RunOverViolation, "TYPE OF EXCEPTION IS WRONG")
+        self.assertEqual(self.gate.transduce(inputs), ['nop', 'ALERT! run off'])
+        self.assertEqual(self.gate.getState(), 'halt', "Violation state is wrong")
 
         
 
@@ -89,19 +93,23 @@ class TestFreeGate(unittest.TestCase):
         test what happen when car exited too son without waiting the gat goes to top
         """
          # SCENARIO: car exit too son hit the gate:
-        inputs = [('bottom', False, False), ('middle', True, False), ('middle', False, True)]
+        inputs = [('bottom', False, False), ('bottom', True, False), ('middle', False, True)]
 
         # assert 
-        with self.assertRaises(Exception) as e:
-            self.gate.transduce(inputs)
+        # with self.assertRaises(Exception) as e:
+        #     self.gate.transduce(inputs)
         
-        self.assertTrue(type(e.exception) is pg.TooSoonViolation, "TYPE OF EXCEPTION IS FALSE")
+        # self.assertTrue(type(e.exception) is pg.TooSoonViolation, "TYPE OF EXCEPTION IS FALSE")
+        self.assertEqual(self.gate.transduce(inputs), ['nop', 'lift', 'ALERT! too soon'])
+        self.assertEqual(self.gate.getState(), 'halt', "Violation state is wrong")
 
         # SCENARIO: car exit while gate is lowering:
-        inputs = [('bottom', False, False), ('middle', True, False), ('top', True, False), ('top', True, True), ('middle', True, False), ('middle', True, True)]
+        inputs = [('bottom', False, False), ('bottom', True, False), ('middle', True, False), ('top', True, False), ('top', True, True), ('middle', False, True)]
         
-        # assert 
-        with self.assertRaises(Exception) as e:
-            self.gate.transduce(inputs)
+        # # assert 
+        # with self.assertRaises(Exception) as e:
+        #     self.gate.transduce(inputs)
         
-        self.assertTrue(type(e.exception) is pg.TooSoonViolation, "TYPE OF EXCEPTION IS FALSE")
+        # self.assertTrue(type(e.exception) is pg.TooSoonViolation, "TYPE OF EXCEPTION IS FALSE")
+        self.assertEqual(self.gate.transduce(inputs), ['nop', 'lift', 'lift', 'nop', 'drop', 'ALERT! too soon'])
+        self.assertEqual(self.gate.getState(), 'halt', "Violation state is wrong")


### PR DESCRIPTION
NOTE: still using super.getNextValues(...) to handle the rest This includes handle the exception still uses the super function

~~Is this enough please review... ~~

Alternatively we can completely override the getNextValue function including the exception handler.

I decided to change the test to test if the ALERT is raised as result of error handling of the violations.

Next I also change the Error function for the next state to be 'halt'